### PR TITLE
Publish CLI to both npm and GitHub Packages

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,8 +14,15 @@
     [
       "@semantic-release/npm",
       {
+        "npmPublish": true
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
         "npmPublish": true,
-        "registry": "https://npm.pkg.github.com"
+        "registry": "https://npm.pkg.github.com",
+        "pkgRoot": "apps/cli"
       }
     ],
     "@semantic-release/github",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,8 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": true
+        "npmPublish": true,
+        "registry": "https://npm.pkg.github.com"
       }
     ],
     "@semantic-release/github",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -19,6 +19,9 @@
   ],
   "author": "harpertoken",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@google/genai": "^1.21.0",
     "chalk": "^5.3.0",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "harpertoken-autofix-cli",
+  "name": "@harpertoken/autofix-cli",
   "version": "1.0.0",
   "description": "CLI for Harper Autofix - AI-powered text completion editor",
   "main": "dist/index.js",


### PR DESCRIPTION
Changes CLI package name to scoped '@harpertoken/autofix-cli' and configures semantic-release to publish to both npm and GitHub Packages. Requires NPM_TOKEN for npm and uses GITHUB_TOKEN for GitHub Packages.