### PR TITLE
Fix release: Publish only to GitHub Packages

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,12 +14,6 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": true
-      }
-    ],
-    [
-      "@semantic-release/npm",
-      {
         "npmPublish": true,
         "registry": "https://npm.pkg.github.com",
         "pkgRoot": "apps/cli"


### PR DESCRIPTION
Removes npm publishing from semantic-release to avoid NPM_TOKEN requirement. Publishes CLI only to GitHub Packages using GITHUB_TOKEN.