### PR TITLE
Fix release: Remove git plugin to avoid branch rule conflicts

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,13 +25,6 @@
         "pkgRoot": "apps/cli"
       }
     ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,12 +14,6 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": true
-      }
-    ],
-    [
-      "@semantic-release/npm",
-      {
         "npmPublish": true,
         "registry": "https://npm.pkg.github.com",
         "pkgRoot": "apps/cli"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,6 +14,12 @@
     [
       "@semantic-release/npm",
       {
+        "npmPublish": true
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
         "npmPublish": true,
         "registry": "https://npm.pkg.github.com",
         "pkgRoot": "apps/cli"


### PR DESCRIPTION
Removes @semantic-release/git plugin to prevent push conflicts with repo branch rules requiring PRs. Changelog generated but not committed.